### PR TITLE
Documentation and decryption padding needed

### DIFF
--- a/Drone/comms/encryption/examples/main.c
+++ b/Drone/comms/encryption/examples/main.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #ifndef AES_KEY_SIZE
 #define AES_KEY_SIZE 32
+#define MESSAGE_SIZE 62
 #endif
 
 int main()
@@ -21,40 +22,87 @@ int main()
         0x3b, 0x61, 0x08, 0xd7,
         0x2d, 0x98, 0x10, 0xa3,
         0x09, 0x14, 0xdf, 0xf4};
-    // Buffer *key_buffer = (Buffer *)malloc(sizeof(unsigned char) * AES_KEY_SIZE + sizeof(usi));
-    // GenerateKey(122, key_buffer, 1);
+    Buffer *key_buffer = (Buffer *)malloc(sizeof(unsigned char) * AES_KEY_SIZE + sizeof(usi));
+    key_buffer->key_size = AES_KEY_SIZE;
+    GenerateKey(213, key_buffer, 1);
     // memcpy(key_buffer->key, key, sizeof(char) * 32);
     // unsigned char key[AES_KEY_SIZE] = GenerateKey()
     // Example plaintext (16 bytes for AES block)
-    unsigned char plaintext_bytes[AES_BLOCK_SIZE] = {
-        0x6b, 0xc1, 0xbe, 0xe2,
-        0x2e, 0x40, 0x9f, 0x96,
-        0xe9, 0x3d, 0x7e, 0x11,
-        0x73, 0x93, 0x17, 0x2a};
+    unsigned char plaintext_bytes[MESSAGE_SIZE] = {
+        0x6b,
+        0xc1,
+        0xbe,
+        0xe2,
+        0x2e,
+        0x40,
+        0x9f,
+        0x96,
+        0xe9,
+        0x3d,
+        0x7e,
+        0x11,
+        0x73,
+        0x93,
+        0x17,
+        0x2a,
+        0x6b,
+        0xc1,
+        0xbe,
+        0xe2,
+        0x2e,
+        0x40,
+        0x9f,
+        0x96,
+        0xe9,
+        0x3d,
+        0x7e,
+        0x11,
+        0x73,
+        0x93,
+        0x17,
+        0x2a,
+        0x6b,
+        0xc1,
+        0xbe,
+        0xe2,
+        0x2e,
+        0x40,
+        0x9f,
+        0x96,
+        0xe9,
+        0x3d,
+        0x7e,
+        0x11,
+        0x73,
+        0x93,
+        0x17,
+        0x2a,
+        0x6b,
+        0xc1,
+        0xbe,
+        0xe2,
+        0x2e,
+        0x40,
+        0x9f,
+        0x96,
+        0xe9,
+        0x3d,
+        0x7e,
+        0x11,
+        0x73,
+        0x93,
+    };
     Message plaintext;
-    plaintext.message_size = AES_BLOCK_SIZE;
+    plaintext.message_size = MESSAGE_SIZE;
     plaintext.message_body = (unsigned char *)plaintext_bytes;
     printf("Starting the encryption\n");
     // Encrypt
-    Message ciphertext = EncryptMessage(&plaintext, key);
     printf("Encrypted message:\n");
-    for (int i = 0; i < ciphertext.message_size; i++)
-    {
-        printf("%02x ", (unsigned char)ciphertext.message_body[i]);
-    }
+    Message encrypted = EncryptMessage(&plaintext, key_buffer->key);
+    // The padding doesn't work as expected, but I can fix it by adding artificatial padding here
+    DecryptMessage(&encrypted, key_buffer->key);
     printf("\n");
-
-    // Expected ciphertext: f3 ee d1 bd b5 d2 a0 3c 06 4b 5a 7e 3d b1 81 f8
-
-    // Decrypt
-    Message decrypted = DecryptMessage(&ciphertext, key);
-    printf("Decrypted message:\n");
-    for (int i = 0; i < decrypted.message_size; i++)
-    {
-        printf("%02x ", (unsigned char)decrypted.message_body[i]);
-    }
-    printf("\n");
-    for (int i = 0; i < plaintext.message_size;i++)
+    for (int i = 0; i < plaintext.message_size; i++)
     {
         printf("%02x ", (unsigned char)plaintext.message_body[i]);
     }

--- a/Drone/comms/encryption/include/encryption.h
+++ b/Drone/comms/encryption/include/encryption.h
@@ -35,11 +35,16 @@ void init(ulli *buffer);
 
 // It's like this for now, we will either settle for specific implementation for each structure,
 // or we will just conver the type using casting and this will take size as an argument
-Message EncryptMessage(Message *message, unsigned char *originalKey);
+
+Message EncryptMessage(Message *message, unsigned char *key);
+
+Message DecryptMessage(Message *message, unsigned char *key);
+
+Message EncryptChunk(Message *message, unsigned char *originalKey);
 
 void AES_Encrypt(unsigned char *message, unsigned char *RoundKey, unsigned char *encrypted);
 
-Message DecryptMessage(Message *message, unsigned char *originalKey);
+Message DecryptChunk(Message *message, unsigned char *originalKey);
 
 void AES_Decrypt(unsigned char *encrypted, unsigned char *RoundKey, unsigned char *decrypted);
 

--- a/Drone/comms/encryption/include/key_generator.h
+++ b/Drone/comms/encryption/include/key_generator.h
@@ -23,6 +23,8 @@ typedef struct
 // Returns 0 when key has been written in the buffer and is ready to be used
 void GenerateKey(ulli seed, Buffer *key_write_buffer, usi random_mode);
 
+void GenerateKeyFuncion(ulli seed, Buffer *key_buffer, usi random_mode, unsigned char (*randomFuncion)());
+
 // Simplest rng
 unsigned char RNG(ulli seed);
 

--- a/Drone/comms/encryption/src/key_generator.c
+++ b/Drone/comms/encryption/src/key_generator.c
@@ -1,5 +1,6 @@
 #include "../include/key_generator.h"
 #include <stdio.h>
+#include <time.h>
 // Gets current time (we could define a counter similar to millis() in arduino)
 unsigned char NRNG()
 {
@@ -9,7 +10,7 @@ unsigned char NRNG()
 // USE FOR TESTING ONLY!!!
 unsigned char RNG(ulli seed)
 {
-    return seed * 0x22;
+    return (unsigned char)(seed * 0x22);
 }
 
 // Generates a cryptografic key for encryption
@@ -19,8 +20,29 @@ void GenerateKey(ulli seed, Buffer *key_buffer, usi random_mode)
     printf("=============== BEGIN KEY ===============\n");
     for (usi key_byte = 0; key_byte < key_size; key_byte++)
     {
-        key_buffer->key[key_byte] = RNG(key_byte + seed);
+        key_buffer->key[key_byte] = RNG(seed + key_byte * (ulli)time(NULL));
         printf("%02x ", key_buffer->key[key_byte]);
+        if (!((key_byte + 1) % 16))
+        {
+            printf("\n");
+        }
+    }
+    printf("=============== END KEY ===============\n");
+}
+
+// Generates a cryptografic key for encryption
+void GenerateKeyFuncion(ulli seed, Buffer *key_buffer, usi random_mode, unsigned char (*randomFuncion)())
+{
+    usi key_size = key_buffer->key_size;
+    printf("=============== BEGIN KEY ===============\n");
+    for (usi key_byte = 0; key_byte < key_size; key_byte++)
+    {
+        key_buffer->key[key_byte] = randomFuncion(seed + key_byte * (ulli)time(NULL));
+        printf("%02x ", key_buffer->key[key_byte]);
+        if (!((key_byte + 1) % 16))
+        {
+            printf("\n");
+        }
     }
     printf("=============== END KEY ===============\n");
 }


### PR DESCRIPTION
As in the title. The main problem with decryption of a message that length is not divisible by 16 gets additional padding, which after decryption scrambles the last chunk ("tail" of the message, the part which has length of b = n (mod 16), where b != 0)